### PR TITLE
fixing issue with tags pages rendering

### DIFF
--- a/templates/tags.thyme
+++ b/templates/tags.thyme
@@ -8,7 +8,7 @@
 		<div class="container">
 	
 			<div class="page-header">
-				<h1 th:text='Tag: ${tag}'>tag</h1>
+				<h1 th:inline='text'>Tag: [[${tag}]]</h1>
 			</div>
 		
 			<div th:each="post : ${tag_posts}" th:with='last_month=null' th:remove='tag'>


### PR DESCRIPTION
This commit fixes error with rendering tags pages (error message: `Could not parse as expression: "Tag: ${tag}" (tags.thyme:11)`) when `render.tags` is set to `true`.
