### PR TITLE
Make 'html5shiv' javascript rootpath relative

### DIFF
--- a/templates/header.thyme
+++ b/templates/header.thyme
@@ -17,7 +17,7 @@
 	
 	    <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
 	    <!--[if lt IE 9]>
-	      <script src="/js/html5shiv.min.js"></script>
+	      <script th:with="rootpath=(${content.rootpath != null} ? ${content.rootpath} : '')" th:src="${rootpath}+'js/html5shiv.min.js'"></script>
 	    <![endif]-->
 	
 	    <!-- Fav and touch icons -->


### PR DESCRIPTION
After JBakes change to use ConditionalCommentsDialect from Thyme
extension this JS can be made rootpath relative, as the other assets
already are.

With commit jbake-org/jbake@d636330c4838206224b7d551c0e9b1ea7d4a00d8 usage of Thyme extension dialect ConditionalCommentDialect was introduced.
'html5shiv' javascript is within an IE conditional and therefore now can be made rootpath relative too, instead of being fixed to absolute '/js/'.